### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.0.0
 tqdm>=4.0.0
+s2dl


### PR DESCRIPTION
s2dl was a missing dependency to make your jupyter notebook examples work