### PR TITLE
Fix: handle IMAGE_FILE_2A tag and restrict to IMG_DATA nodes for older Sentinel-2 L2A products

### DIFF
--- a/s2dl/s2dl.py
+++ b/s2dl/s2dl.py
@@ -167,7 +167,13 @@ def fetch_product_data(
         xml_url = f"{download_url}MTD_MSIL2A.xml"
     xml_dom_tree = get_xml(session, xml_url)
 
-    image_file_nodes = xml_dom_tree.getElementsByTagName("IMAGE_FILE")
+    image_file_nodes = list(
+            filter(
+                lambda node: node.tagName in ("IMAGE_FILE_2A", "IMAGE_FILE"),
+                xml_dom_tree.getElementsByTagName("*")
+            )
+        )
+    image_file_nodes = list(filter(lambda node: "/IMG_DATA/" in node.firstChild.data, image_file_nodes))
 
     image_files_urls = [
         f"{download_url}{node.firstChild.data}.jp2" for node in image_file_nodes  # type: ignore  # noqa: E501


### PR DESCRIPTION
### Summary
This PR fixes an issue with older Sentinel-2 L2A products (e.g. 2017) that fail with  
“Sorry we failed to find product {product_id}” because their XML metadata  
uses `<IMAGE_FILE_2A>` instead of `<IMAGE_FILE>`.

### Changes
- Detects both `IMAGE_FILE` and `IMAGE_FILE_2A` tags.
- Filters only nodes within `/IMG_DATA/` paths.
- Keeps backward compatibility with recent products.

### Testing
Validated with:
- ✅ `S2A_MSIL2A_20170518T113321_N0205_R080_T28RGU_20170518T113412`
- ✅ Several 2021–2023 L2A products.

### Result
Old L2A products now download correctly from GCP Sentinel-2 public data bucket.